### PR TITLE
Add filtering option to keep only certain domain records.

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -417,6 +417,10 @@ multiplexer:
 #   drop-fqdn-file: ""
 #   # path file of the domain drop list, domains list can be a partial domain name with regexp expression
 #   drop-domain-file: ""
+#   # path file of the fqdn keep list (all others are dropped), domains list must be a full qualified domain name
+#   keep-fqdn-file: ""
+#   # path file of the domain keep list (all others are dropped), domains list can be a partial domain name with regexp expression
+#   keep-domain-file: ""
 #   # path file of the query IP drop list, one IP address or subnet per line
 #   drop-queryip-file: ""
 #   # path file of the query IP keep list, one IP address or subnet per line

--- a/dnsutils/config.go
+++ b/dnsutils/config.go
@@ -96,6 +96,8 @@ type Config struct {
 		Filtering struct {
 			DropFqdnFile    string   `yaml:"drop-fqdn-file"`
 			DropDomainFile  string   `yaml:"drop-domain-file"`
+			KeepFqdnFile    string   `yaml:"keep-fqdn-file"`
+			KeepDomainFile  string   `yaml:"keep-domain-file"`
 			DropQueryIpFile string   `yaml:"drop-queryip-file"`
 			KeepQueryIpFile string   `yaml:"keep-queryip-file"`
 			DropRcodes      []string `yaml:"drop-rcodes,flow"`
@@ -316,6 +318,8 @@ func (c *Config) SetDefault() {
 
 	c.Transformers.Filtering.DropFqdnFile = ""
 	c.Transformers.Filtering.DropDomainFile = ""
+	c.Transformers.Filtering.KeepFqdnFile = ""
+	c.Transformers.Filtering.KeepDomainFile = ""
 	c.Transformers.Filtering.DropQueryIpFile = ""
 	c.Transformers.Filtering.DropRcodes = []string{}
 	c.Transformers.Filtering.LogQueries = true

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -230,6 +230,8 @@ This feature can be useful to increase logging performance..
 Options:
 - `drop-fqdn-file`: (string) path file to a fqdn drop list, domains list must be a full qualified domain name
 - `drop-domain-file`: (string) path file to domain drop list, domains list can be a partial domain name with regexp expression
+- `keep-fqdn-file`: (string) path file to a fqdn keep list (all others are dropped), domains list must be a full qualified domain name
+- `keep-domain-file`: (string) path file to domain keep list (all others are dropped), domains list can be a partial domain name with regexp expression
 - `drop-queryip-file`: (string) path file to the query ip or ip prefix drop list
 - `keep-queryip-file`: (string) path file to the query ip or ip prefix keep list, addresses in both drop and keep are always kept
 - `drop-rcodes`: (list of string) rcode list, empty by default
@@ -241,6 +243,8 @@ transforms:
   filtering:
     drop-fqdn-file: ""
     drop-domain-file: ""
+    keep-fqdn-file: ""
+    keep-domain-file: ""
     drop-queryip-file: ""
     keep-queryip-file: ""
     drop-rcodes: []

--- a/testsdata/filtering_keep_domains.txt
+++ b/testsdata/filtering_keep_domains.txt
@@ -1,0 +1,2 @@
+google.fr
+test.github.com

--- a/testsdata/filtering_keep_domains_regex.txt
+++ b/testsdata/filtering_keep_domains_regex.txt
@@ -1,0 +1,3 @@
+(mail|sheets)\.google\.com$
+test\.github\.com$
+.+\.google\.com$

--- a/transformers/filtering.go
+++ b/transformers/filtering.go
@@ -27,8 +27,9 @@ type FilteringProcessor struct {
 	listKeepDomainsRegex  map[string]*regexp.Regexp
 	fileWatcher           *fsnotify.Watcher
 	name                  string
-	downsample       int
-	downsampleCount  int
+	downsample            int
+	downsampleCount       int
+}
 
 func NewFilteringProcessor(config *dnsutils.Config, logger *logger.Logger, name string) FilteringProcessor {
 	// creates a new file watcher

--- a/transformers/filtering.go
+++ b/transformers/filtering.go
@@ -14,16 +14,19 @@ import (
 )
 
 type FilteringProcessor struct {
-	config           *dnsutils.Config
-	logger           *logger.Logger
-	dropDomains      bool
-	mapRcodes        map[string]bool
-	ipsetDrop        *netaddr.IPSet
-	ipsetKeep        *netaddr.IPSet
-	listFqdns        map[string]bool
-	listDomainsRegex map[string]*regexp.Regexp
-	fileWatcher      *fsnotify.Watcher
-	name             string
+	config                *dnsutils.Config
+	logger                *logger.Logger
+	dropDomains           bool
+	keepDomains           bool
+	mapRcodes             map[string]bool
+	ipsetDrop             *netaddr.IPSet
+	ipsetKeep             *netaddr.IPSet
+	listFqdns             map[string]bool
+	listDomainsRegex      map[string]*regexp.Regexp
+	listKeepFqdns         map[string]bool
+	listKeepDomainsRegex  map[string]*regexp.Regexp
+	fileWatcher           *fsnotify.Watcher
+	name                  string
 }
 
 func NewFilteringProcessor(config *dnsutils.Config, logger *logger.Logger, name string) FilteringProcessor {
@@ -35,15 +38,17 @@ func NewFilteringProcessor(config *dnsutils.Config, logger *logger.Logger, name 
 	defer watcher.Close()
 
 	d := FilteringProcessor{
-		config:           config,
-		logger:           logger,
-		mapRcodes:        make(map[string]bool),
-		ipsetDrop:        &netaddr.IPSet{},
-		ipsetKeep:        &netaddr.IPSet{},
-		listFqdns:        make(map[string]bool),
-		listDomainsRegex: make(map[string]*regexp.Regexp),
-		fileWatcher:      watcher,
-		name:             name,
+		config:                config,
+		logger:                logger,
+		mapRcodes:             make(map[string]bool),
+		ipsetDrop:             &netaddr.IPSet{},
+		ipsetKeep:             &netaddr.IPSet{},
+		listFqdns:             make(map[string]bool),
+		listDomainsRegex:      make(map[string]*regexp.Regexp),
+		listKeepFqdns:         make(map[string]bool),
+		listKeepDomainsRegex:  make(map[string]*regexp.Regexp),
+		fileWatcher:           watcher,
+		name:                  name,
 	}
 
 	d.LoadRcodes()
@@ -160,8 +165,40 @@ func (p *FilteringProcessor) LoadDomainsList() {
 			p.LogInfo("loaded with %d domains to the drop list", len(p.listDomainsRegex))
 			p.dropDomains = true
 		}
-
 	}
+
+	if len(p.config.Transformers.Filtering.KeepFqdnFile) > 0 {
+		file, err := os.Open(p.config.Transformers.Filtering.KeepFqdnFile)
+		if err != nil {
+			p.LogError("unable to open KeepFqdnFile file: ", err)
+			p.keepDomains = false 
+		} else {
+			scanner := bufio.NewScanner(file)
+			for scanner.Scan() {
+				keepDomain := strings.ToLower(scanner.Text())
+				p.listKeepFqdns[keepDomain] = true 
+			}
+			p.LogInfo("loaded with %d fqdns to the keep list", len(p.listKeepFqdns))
+			p.keepDomains = true
+		}
+	} 
+
+	if len(p.config.Transformers.Filtering.KeepDomainFile) > 0 {
+		file, err := os.Open(p.config.Transformers.Filtering.KeepDomainFile)
+		if err != nil {
+			p.LogError("unable to open KeepDomainFile file: ", err)
+			p.keepDomains = false 
+		} else {
+			scanner := bufio.NewScanner(file)
+			for scanner.Scan() {
+				keepDomain := strings.ToLower(scanner.Text())
+				p.listKeepDomainsRegex[keepDomain] = regexp.MustCompile(keepDomain) 
+			}
+			p.LogInfo("loaded with %d domains to the keep list", len(p.listKeepDomainsRegex))
+			p.keepDomains = true
+		}
+	} 
+
 }
 
 func (p *FilteringProcessor) LogInfo(msg string, v ...interface{}) {
@@ -225,6 +262,23 @@ func (p *FilteringProcessor) CheckIfDrop(dm *dnsutils.DnsMessage) bool {
 			}
 		}
 	}
+
+	// only certain domains ? read list but flip the responses.
+	if p.keepDomains {
+		// only 
+		if _, ok := p.listKeepFqdns[dm.DNS.Qname]; ok {
+			return false 
+		}
+
+		// partiel fqdn with regexp
+		for _, r := range p.listKeepDomainsRegex {
+			if r.MatchString(dm.DNS.Qname) {
+				return false
+			}
+		}
+
+		return true
+	} 
 
 	return false
 }

--- a/transformers/filtering_test.go
+++ b/transformers/filtering_test.go
@@ -173,7 +173,7 @@ func TestFilteringByKeepDomain(t *testing.T) {
 
 func TestFilteringByKeepDomainRegex(t *testing.T) {
 	// config
-	config := dnsutils.GetFakeConfig
+	config := dnsutils.GetFakeConfig()
 
 	/* file contains:
 	(mail|sheets).google.com$

--- a/transformers/filtering_test.go
+++ b/transformers/filtering_test.go
@@ -142,8 +142,9 @@ func TestFilteringByDomainRegex(t *testing.T) {
 func TestFilteringByKeepDomain(t *testing.T) {
 	// config
 	config := dnsutils.GetFakeConfig()
+	
+	// file contains google.fr, test.github.com
 	config.Transformers.Filtering.KeepDomainFile = "../testsdata/filtering_keep_domains.txt"
-  // file contains google.fr, test.github.com
 
 	// init subproccesor
 	filtering := NewFilteringProcessor(config, logger.New(false), "test")
@@ -172,14 +173,14 @@ func TestFilteringByKeepDomain(t *testing.T) {
 
 func TestFilteringByKeepDomainRegex(t *testing.T) {
 	// config
-	config := dnsutils.GetFakeConfig()
-	config.Transformers.Filtering.KeepDomainFile = "../testsdata/filtering_keep_domains_regex.txt"
+	config := dnsutils.GetFakeConfig
 
-  /* file contains:
-    (mail|sheets).google.com$
-    test.github.com$
-    .+.google.com$
-  */
+	/* file contains:
+	(mail|sheets).google.com$
+	test.github.com$
+	.+.google.com$
+	*/
+	config.Transformers.Filtering.KeepDomainFile = "../testsdata/filtering_keep_domains_regex.txt"
 
 	// init subproccesor
 	filtering := NewFilteringProcessor(config, logger.New(false), "test")
@@ -213,6 +214,10 @@ func TestFilteringByDownsample(t *testing.T) {
 	config := dnsutils.GetFakeConfig()
 	config.Transformers.Filtering.Downsample = 2
 
+	// init subproccesor
+	filtering := NewFilteringProcessor(config, logger.New(false), "test")
+	dm := dnsutils.GetFakeDnsMessage()
+	
 	// filtering.downsampleCount 
 	if filtering.CheckIfDrop(&dm) == false {
 		t.Errorf("dns query should be dropped! downsampled should exclude first hit.")


### PR DESCRIPTION
This PR adds a filter for "keep domains", where all except specified domains are dropped. 

This functionally works exactly the opposite of the existing dropDomains filters for fqdns and domain regexes. With the existing `dropDomains` filter, all domains are kept *except* those that are listed in the `DropDomainFile` or `DropFqdnFile`: with this new `keepDomains` filter, all domains are *dropped* except for those that are listed in the `KeepDomainFile` or the `KeepFqdnFile`.

