### PR TITLE
Add downsampling filter.

### DIFF
--- a/dnsutils/config.go
+++ b/dnsutils/config.go
@@ -101,6 +101,7 @@ type Config struct {
 			DropRcodes      []string `yaml:"drop-rcodes,flow"`
 			LogQueries      bool     `yaml:"log-queries"`
 			LogReplies      bool     `yaml:"log-replies"`
+			Downsample      int      `yaml:"downsample"`
 		} `yaml:"filtering"`
 		GeoIP struct {
 			DbCountryFile string `yaml:"mmdb-country-file"`
@@ -320,6 +321,7 @@ func (c *Config) SetDefault() {
 	c.Transformers.Filtering.DropRcodes = []string{}
 	c.Transformers.Filtering.LogQueries = true
 	c.Transformers.Filtering.LogReplies = true
+	c.Transformers.Filtering.Downsample = 0
 
 	c.Transformers.GeoIP.DbCountryFile = ""
 	c.Transformers.GeoIP.DbCityFile = ""

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -224,6 +224,7 @@ The filtering feature can be used to ignore some queries or replies according to
 - qname
 - return code
 - query ip
+- sampling rate
 
 This feature can be useful to increase logging performance..
 
@@ -235,6 +236,7 @@ Options:
 - `drop-rcodes`: (list of string) rcode list, empty by default
 - `log-queries`: (boolean) forward received queries to configured loggers
 - `log-replies`: (boolean)  forward received replies to configured loggers
+- `downsample`: (integer) only keep 1 out of every `downsample` records, e.g. if set to 20, then this will return every 20th record, dropping 95% of queries 
 
 ```yaml
 transforms:
@@ -246,6 +248,7 @@ transforms:
     drop-rcodes: []
     log-queries: true
     log-replies: true
+    downsample: 0
 ```
 
 Domain list with regex example:

--- a/transformers/filtering_test.go
+++ b/transformers/filtering_test.go
@@ -138,3 +138,43 @@ func TestFilteringByDomainRegex(t *testing.T) {
 		t.Errorf("dns query should not be dropped!")
 	}
 }
+
+func TestFilteringByDownsample(t *testing.T) {
+	// config
+	config := dnsutils.GetFakeConfig()
+	config.Transformers.Filtering.Downsample = 2
+
+	// init subproccesor
+	filtering := NewFilteringProcessor(config, logger.New(false), "test")
+
+	dm := dnsutils.GetFakeDnsMessage()
+
+	// filtering.downsampleCount 
+	if filtering.CheckIfDrop(&dm) == false {
+		t.Errorf("dns query should be dropped! downsampled should exclude first hit.")
+	}
+
+	if filtering.CheckIfDrop(&dm) == true {
+		t.Errorf("dns query should not be dropped! downsampled one record and then should include the next if downsample rate is 2")
+	}
+
+	if filtering.CheckIfDrop(&dm) == false {
+		t.Errorf("dns query should be dropped! downsampled should exclude first hit.")
+	}
+
+	if filtering.CheckIfDrop(&dm) == true {
+		t.Errorf("dns query should not be dropped! downsampled one record and then should include the next if downsample rate is 2")
+	}
+
+	// test for default behavior when downsample is set to 0
+	config.Transformers.Filtering.Downsample = 0
+	filtering = NewFilteringProcessor(config, logger.New(false), "test")
+
+	if filtering.CheckIfDrop(&dm) == true {
+		t.Errorf("dns query should not be dropped! downsampling rate is set to 0 and should not downsample.")
+	}
+	if filtering.CheckIfDrop(&dm) == true {
+		t.Errorf("dns query should not be dropped! downsampling rate is set to 0 and should not downsample.")
+	}
+
+}


### PR DESCRIPTION
In high-volume monitoring contexts, it may be desirable to only sample a small proportion of DNS traffic. This PR provides a new filtering option, `downsample`, which takes an integer as a parameter which causes the filter to only return 1 out of every `downsample` records from the collector, dropping the rest. Therefore, if `downsample` is set to 2, then 1/2 or 50% of records are returned, or if it is set to 100, then only 1/100 or 1% of records are returned.