### PR TITLE
GH actions: some actions are deprecated.

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - uses: actions/setup-go@v3
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@v4
 
     - uses: actions/checkout@v3
       with:

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -15,11 +15,11 @@ jobs:
     - uses: actions/setup-go@v2
     - uses: actions/setup-python@v2
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         path: app
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         repository: dmachard/go-dnstap-generator
         path: gen

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -14,6 +14,8 @@ jobs:
     steps:
     - uses: actions/setup-go@v3
     - uses: actions/setup-python@v4
+      with:
+        python-version: '3.11'
 
     - uses: actions/checkout@v3
       with:

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -12,7 +12,7 @@ jobs:
   bench-dnstaptcp:
     runs-on: ubuntu-22.04
     steps:
-    - uses: actions/setup-go@v2
+    - uses: actions/setup-go@v3
     - uses: actions/setup-python@v2
 
     - uses: actions/checkout@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
         go-version: ['1.19']
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: actions/setup-go@v2
       with:
         go-version: ${{ matrix.go-version }}
@@ -34,7 +34,7 @@ jobs:
         go-version: [ '1.19' ]
         
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: actions/setup-go@v2
       with:
         go-version: ${{ matrix.go-version }}
@@ -50,7 +50,7 @@ jobs:
         go-version: [ '1.19' ]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: actions/setup-go@v2
       with:
         go-version: ${{ matrix.go-version }}
@@ -63,7 +63,7 @@ jobs:
   docker:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Build the Docker image
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - uses: actions/setup-go@v2
+    - uses: actions/setup-go@v3
       with:
         go-version: ${{ matrix.go-version }}
 
@@ -35,7 +35,7 @@ jobs:
         
     steps:
     - uses: actions/checkout@v3
-    - uses: actions/setup-go@v2
+    - uses: actions/setup-go@v3
       with:
         go-version: ${{ matrix.go-version }}
 
@@ -51,7 +51,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - uses: actions/setup-go@v2
+    - uses: actions/setup-go@v3
       with:
         go-version: ${{ matrix.go-version }}
 

--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: actions/setup-go@v2
       with:
         go-version: '1.19'

--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - uses: actions/setup-go@v2
+    - uses: actions/setup-go@v3
       with:
         go-version: '1.19'
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,30 +6,10 @@ on:
 
 jobs:
 
-  # go:
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v2
-
-  #     - uses: actions/setup-go@v2
-  #       with:
-  #         go-version: 1.18
-
-  #     - name: Build
-  #       run: |
-  #         CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags="-X 'main.Version=${{ github.event.release.tag_name }}'" -o go-dnscollector *.go
-  #         tar -cvzf go-dnscollector_${{ github.event.release.tag_name }}_linux_amd64.tar.gz go-dnscollector config.yml
-
-  #     - name: Release
-  #       uses: softprops/action-gh-release@v1
-  #       with:
-  #         tag_name: ${{ github.event.release.tag_name }}
-  #         files: go-dnscollector_${{ github.event.release.tag_name }}_linux_amd64.tar.gz
-
   dockerhub:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Build the Docker image
       run: |

--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Go
         uses: actions/setup-go@v2

--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -17,7 +17,7 @@ jobs:
           go-version: 1.19
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v2
+        uses: goreleaser/goreleaser-action@v3
         with:
           version: latest
           args: release --rm-dist

--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -12,7 +12,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: 1.19
 

--- a/.github/workflows/testing-dnstap.yml
+++ b/.github/workflows/testing-dnstap.yml
@@ -27,6 +27,8 @@ jobs:
       with:
         go-version: ${{ matrix.go-version }}
     - uses: actions/setup-python@v4
+      with:
+        python-version: '3.11'
 
     - name: build binary
       run: CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o go-dnscollector *.go
@@ -58,6 +60,8 @@ jobs:
       with:
         go-version: ${{ matrix.go-version }}
     - uses: actions/setup-python@v4
+      with:
+        python-version: '3.11'
 
     - name: build binary
       run: CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o go-dnscollector *.go
@@ -91,6 +95,8 @@ jobs:
       with:
         go-version: ${{ matrix.go-version }}
     - uses: actions/setup-python@v4
+      with:
+        python-version: '3.11'
 
     - name: build binary
       run: CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o go-dnscollector *.go

--- a/.github/workflows/testing-dnstap.yml
+++ b/.github/workflows/testing-dnstap.yml
@@ -26,7 +26,7 @@ jobs:
     - uses: actions/setup-go@v3
       with:
         go-version: ${{ matrix.go-version }}
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@v4
 
     - name: build binary
       run: CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o go-dnscollector *.go
@@ -57,7 +57,7 @@ jobs:
     - uses: actions/setup-go@v3
       with:
         go-version: ${{ matrix.go-version }}
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@v4
 
     - name: build binary
       run: CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o go-dnscollector *.go
@@ -90,7 +90,7 @@ jobs:
     - uses: actions/setup-go@v3
       with:
         go-version: ${{ matrix.go-version }}
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@v4
 
     - name: build binary
       run: CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o go-dnscollector *.go

--- a/.github/workflows/testing-dnstap.yml
+++ b/.github/workflows/testing-dnstap.yml
@@ -22,8 +22,8 @@ jobs:
         mode: [ 'tcp' ]
 
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-go@v2
+    - uses: actions/checkout@v3
+    - uses: actions/setup-go@v3
       with:
         go-version: ${{ matrix.go-version }}
     - uses: actions/setup-python@v2
@@ -53,8 +53,8 @@ jobs:
         mode: [ 'tcp', 'unix' ]
 
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-go@v2
+    - uses: actions/checkout@v3
+    - uses: actions/setup-go@v3
       with:
         go-version: ${{ matrix.go-version }}
     - uses: actions/setup-python@v2
@@ -86,8 +86,8 @@ jobs:
         mode: [ 'dnstaptcp', 'dnstapunix' ]
 
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-go@v2
+    - uses: actions/checkout@v3
+    - uses: actions/setup-go@v3
       with:
         go-version: ${{ matrix.go-version }}
     - uses: actions/setup-python@v2

--- a/.github/workflows/testing-go.yml
+++ b/.github/workflows/testing-go.yml
@@ -46,6 +46,8 @@ jobs:
       with:
         go-version: ${{ matrix.go-version }}
     - uses: actions/setup-python@v4
+      with:
+        python-version: '3.11'
  
     - name: build binary
       run: CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o go-dnscollector *.go

--- a/.github/workflows/testing-go.yml
+++ b/.github/workflows/testing-go.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ${{ matrix.os-version }}
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: actions/setup-go@v2
       with:
         go-version: ${{ matrix.go-version }}
@@ -41,7 +41,7 @@ jobs:
         package: ['config', 'clientquery_dnstaptcp', 'clientquery_dnstapunix' ]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: actions/setup-go@v2
       with:
         go-version: ${{ matrix.go-version }}
@@ -64,7 +64,7 @@ jobs:
         go-version: ['1.19']
         
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: actions/setup-go@v2
       with:
         go-version: ${{ matrix.go-version }}

--- a/.github/workflows/testing-go.yml
+++ b/.github/workflows/testing-go.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - uses: actions/setup-go@v2
+    - uses: actions/setup-go@v3
       with:
         go-version: ${{ matrix.go-version }}
 
@@ -42,7 +42,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - uses: actions/setup-go@v2
+    - uses: actions/setup-go@v3
       with:
         go-version: ${{ matrix.go-version }}
     - uses: actions/setup-python@v2
@@ -65,7 +65,7 @@ jobs:
         
     steps:
     - uses: actions/checkout@v3
-    - uses: actions/setup-go@v2
+    - uses: actions/setup-go@v3
       with:
         go-version: ${{ matrix.go-version }}
  

--- a/.github/workflows/testing-go.yml
+++ b/.github/workflows/testing-go.yml
@@ -45,7 +45,7 @@ jobs:
     - uses: actions/setup-go@v3
       with:
         go-version: ${{ matrix.go-version }}
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@v4
  
     - name: build binary
       run: CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o go-dnscollector *.go

--- a/.github/workflows/testing-powerdns.yml
+++ b/.github/workflows/testing-powerdns.yml
@@ -25,7 +25,7 @@ jobs:
     - uses: actions/setup-go@v3
       with:
         go-version: ${{ matrix.go-version }}
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@v4
 
     - name: build binary
       run: CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o go-dnscollector *.go
@@ -58,7 +58,7 @@ jobs:
     - uses: actions/setup-go@v3
       with:
         go-version: ${{ matrix.go-version }}
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@v4
 
     - name: build binary
       run: CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o go-dnscollector *.go

--- a/.github/workflows/testing-powerdns.yml
+++ b/.github/workflows/testing-powerdns.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - uses: actions/setup-go@v2
+    - uses: actions/setup-go@v3
       with:
         go-version: ${{ matrix.go-version }}
     - uses: actions/setup-python@v2
@@ -55,7 +55,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - uses: actions/setup-go@v2
+    - uses: actions/setup-go@v3
       with:
         go-version: ${{ matrix.go-version }}
     - uses: actions/setup-python@v2

--- a/.github/workflows/testing-powerdns.yml
+++ b/.github/workflows/testing-powerdns.yml
@@ -21,7 +21,7 @@ jobs:
         dnsdist: [ '17' ]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: actions/setup-go@v2
       with:
         go-version: ${{ matrix.go-version }}
@@ -54,7 +54,7 @@ jobs:
         recursor: [ '47' ]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: actions/setup-go@v2
       with:
         go-version: ${{ matrix.go-version }}

--- a/.github/workflows/testing-powerdns.yml
+++ b/.github/workflows/testing-powerdns.yml
@@ -26,14 +26,11 @@ jobs:
       with:
         go-version: ${{ matrix.go-version }}
     - uses: actions/setup-python@v4
+      with:
+        python-version: '3.11'
 
     - name: build binary
       run: CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o go-dnscollector *.go
-
-    # - name: add pdns user
-    #   run: |
-    #     sudo addgroup --system --gid 953 pdns
-    #     sudo adduser --system --disabled-password --no-create-home -uid 953 --gid 953 pdns
 
     - name: Deploy dnsdist docker image
       run: |
@@ -59,6 +56,8 @@ jobs:
       with:
         go-version: ${{ matrix.go-version }}
     - uses: actions/setup-python@v4
+      with:
+        python-version: '3.11'
 
     - name: build binary
       run: CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o go-dnscollector *.go


### PR DESCRIPTION
PR to fix the following warning in GH actions:

`Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: actions/checkout, actions/setup-go, actions/checkout`

`The set-output command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/`

`The python-version input is not set. The version of Python currently in `PATH` will be used.`