### PR TITLE
Add syslog format

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -311,6 +311,8 @@ multiplexer:
 #   tls-support: false
 #   # insecure skip verify
 #   tls-insecure: false
+#   # set syslog formatter between `unix` (default), `rfc3164` or `rfc5424`
+#   format: ""
 
 # # resend captured dns traffic to a remote fluentd server or to unix socket
 # fluentd:

--- a/dnsutils/config.go
+++ b/dnsutils/config.go
@@ -3,7 +3,7 @@ package dnsutils
 import (
 	"os"
 
-	"gopkg.in/yaml.v3"
+	"gopkg.in/yaml.v2"
 )
 
 func IsValidMode(mode string) bool {
@@ -268,6 +268,7 @@ type Config struct {
 			TlsSupport    bool   `yaml:"tls-support"`
 			TlsInsecure   bool   `yaml:"tls-insecure"`
 			TlsMinVersion string `yaml:"tls-min-version"`
+			Format        string `yaml:"format"`
 		} `yaml:"syslog"`
 		Fluentd struct {
 			Enable        bool   `yaml:"enable"`

--- a/dnsutils/config.go
+++ b/dnsutils/config.go
@@ -3,7 +3,7 @@ package dnsutils
 import (
 	"os"
 
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 )
 
 func IsValidMode(mode string) bool {

--- a/doc/loggers.md
+++ b/doc/loggers.md
@@ -256,6 +256,7 @@ Options:
 - `tls-support`: (boolean) enable tls
 - `tls-insecure`: (boolean) insecure skip verify
 - `tls-min-version`: (string) min tls version, default to 1.2
+- `format`: (string) Set syslog formatter between `unix` (default), `rfc3164` (see: https://www.rfc-editor.org/rfc/rfc3164 ) or `rfc5424` (see: https://www.rfc-editor.org/rfc/rfc5424)
 
 Default values:
 
@@ -270,6 +271,7 @@ syslog:
   tls-support: false
   tls-insecure: false
   tls-min-version: 1.2
+  format: ""
 ```
 
 ### Fluentd Client

--- a/loggers/syslog.go
+++ b/loggers/syslog.go
@@ -172,6 +172,14 @@ func (o *Syslog) Run() {
 			}
 		}
 	}
+
+	switch strings.ToLower(o.config.Loggers.Syslog.Format) {
+	case "rfc3164":
+		syslogconn.SetFormatter(syslog.RFC3164Formatter)
+	case "rfc5424":
+		syslogconn.SetFormatter(syslog.RFC5424Formatter)
+	}
+
 	o.syslogConn = syslogconn
 
 	for dm := range o.channel {


### PR DESCRIPTION
On syslog logger it is useful to set which syslog format we want between unix (default one), [rfc3164](https://www.rfc-editor.org/rfc/rfc3164) and [rfc5424](https://www.rfc-editor.org/rfc/rfc5424).

This PR add to syslog config parameter to syslog which accept rfc3164 and rfc5424 as value and set the syslog formatter linked to this format.