### PR TITLE
Added handling for EINTR on syscall.Recvmsg

### DIFF
--- a/collectors/sniffer_afpacket.go
+++ b/collectors/sniffer_afpacket.go
@@ -5,6 +5,7 @@ package collectors
 
 import (
 	"encoding/binary"
+	"errors"
 	"net"
 	"os"
 	"syscall"
@@ -328,7 +329,7 @@ func (c *AfpacketSniffer) Run() {
 			//flags, from
 			bufN, oobn, _, _, err := syscall.Recvmsg(c.fd, buf, oob, 0)
 			if err != nil {
-				if err == syscall.EINTR {
+				if errors.Is(err, syscall.EINTR) {
 					continue
 				} else {
 					panic(err)

--- a/collectors/sniffer_afpacket.go
+++ b/collectors/sniffer_afpacket.go
@@ -328,7 +328,11 @@ func (c *AfpacketSniffer) Run() {
 			//flags, from
 			bufN, oobn, _, _, err := syscall.Recvmsg(c.fd, buf, oob, 0)
 			if err != nil {
-				panic(err)
+				if err == syscall.EINTR {
+					continue
+				} else {
+					panic(err)
+				}
 			}
 			if bufN == 0 {
 				panic("buf empty")


### PR DESCRIPTION
I ran into an issue on some of my DNS servers where go-dnscollector would panic either immediately or not long after starting with the message
```
panic: interrupted system call
```

It seems that the go syscall package does not natively retry after receiving EINTR on Recvmsg and passes it back to the application to handle See [this change](https://go-review.googlesource.com/c/go/+/232862) for examples.

This pull request is to handle this scenario and continue processing after EINTR rather than panicking.